### PR TITLE
API: Lab Results Inbox (POST /api/lab-results/inbox) + API key auth + per-key rate limit

### DIFF
--- a/app/Http/Controllers/Api/LabResultsInboxController.php
+++ b/app/Http/Controllers/Api/LabResultsInboxController.php
@@ -1,0 +1,84 @@
+<?php
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\Rule;
+
+class LabResultsInboxController extends Controller
+{
+    /**
+     * POST /api/lab-results/inbox
+     *
+     * Requirements:
+     * - Auth via X-API-Key (handled by verify.apikey middleware)
+     * - Throttle via named limiter "labresults"
+     * - Validate: source  {TC3060, TEK8520}; obx non-empty; each item has test_name + value
+     * - Normalize: uppercase source; patient_id used as mcu_code
+     * - Insert only into lab_results_inbox_t; store payload verbatim; trigger fills status/items_count/run_at
+     * - Response: { ok:true, inbox_id, mcu_id|null, status }
+     */
+    public function store(Request $request)
+    {
+        // Validate basic shape
+        $validated = $request->validate([
+            'source'       => ['required', 'string'],
+            'patient_id'   => ['nullable', 'string'],
+            'generated_at' => ['nullable', 'string'],
+            'excel_file'   => ['nullable', 'string'],
+            'bridge_version' => ['nullable', 'string'],
+            'obx'          => ['required', 'array', 'min:1'],
+            'obx.*.test_name' => ['required', 'string'],
+            'obx.*.value'     => ['required'], // allow string/number
+        ]);
+
+        // Normalize/guard source AFTER validation
+        $source = strtoupper($validated['source']);
+        if (!in_array($source, ['TC3060', 'TEK8520'], true)) {
+            return response()->json([
+                'message' => 'The source must be either TC3060 or TEK8520.'
+            ], 422);
+        }
+
+        // Use patient_id as mcu_code if present
+        $mcuCode = $validated['patient_id'] ?? null;
+
+        // Store the payload VERBATIM as sent (do not mutate)
+        $payload = $request->all();
+
+        // Insert into inbox table; let DB trigger resolve fields
+        // Note: primary key column is assumed to be "inbox_id".
+        $now = now();
+        $inboxId = DB::table('lab_results_inbox_t')
+            ->insertGetId([
+                'source'     => $source,
+                'mcu_code'   => $mcuCode,
+                'payload'    => json_encode($payload), // jsonb will accept JSON text
+                'created_at' => $now,
+                'updated_at' => $now,
+            ], 'inbox_id');
+
+        // Read back resolved fields (trigger ran BEFORE INSERT)
+        $row = DB::table('lab_results_inbox_t')
+            ->select('inbox_id', 'mcu_id', 'status')
+            ->where('inbox_id', $inboxId)
+            ->first();
+
+        // Log success (nice-to-have)
+        Log::info('lab_inbox.accepted', [
+            'api_key_id' => $request->attributes->get('api_key_id'),
+            'inbox_id'   => $inboxId,
+            'mcu_id'     => $row->mcu_id ?? null,
+            'status'     => $row->status ?? null,
+        ]);
+
+        return response()->json([
+            'ok'       => true,
+            'inbox_id' => $inboxId,
+            'mcu_id'   => $row->mcu_id ?? null,
+            'status'   => $row->status ?? null,
+        ], 200);
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -65,5 +65,6 @@ class Kernel extends HttpKernel
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'role' => \App\Http\Middleware\Role::class,
+        'verify.apikey' => \App\Http\Middleware\VerifyApiKey::class,
     ];
 }

--- a/app/Http/Middleware/VerifyApiKey.php
+++ b/app/Http/Middleware/VerifyApiKey.php
@@ -1,0 +1,45 @@
+<?php
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Symfony\Component\HttpFoundation\Response;
+
+class VerifyApiKey
+{
+    /**
+     * Checks for X-API-Key (case-insensitive), validates against api_keys table.
+     * - 401 if header missing
+     * - 403 if key invalid/inactive
+     * On success, attaches api_key_id to request.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        // Header is case-insensitive; Laravel normalizes, but we check robustly.
+        $header = $request->header('X-API-Key');
+        if (!$header) {
+            // Also try lower-case just in case a client sent it oddly
+            $header = $request->headers->get('x-api-key');
+        }
+
+        if (!$header) {
+            return response()->json(['message' => 'X-API-Key header is required'], 401);
+        }
+
+        // Look up in DB
+        $row = DB::table('api_keys')
+            ->where('api_key', $header)
+            ->where('active', true)
+            ->first();
+
+        if (!$row) {
+            return response()->json(['message' => 'Invalid or inactive API key'], 403);
+        }
+
+        // Attach api_key_id for downstream logging
+        $request->attributes->set('api_key_id', $row->id);
+
+        return $next($request);
+    }
+}

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -22,6 +22,17 @@ class RouteServiceProvider extends ServiceProvider
     /**
      * Define your route model bindings, pattern filters, and other route configuration.
      */
+    protected function configureRateLimiting(): void
+    {
+        RateLimiter::for('labresults', function (Request $request) {
+            // Prefer per-key limit; if header missing, fallback to client IP
+            $keyFromHeader = $request->header('X-API-Key') ?: $request->headers->get('x-api-key');
+            $identifier = $keyFromHeader ?: $request->ip();
+
+            return Limit::perMinute(60)->by($identifier);
+        });
+    }
+
     public function boot(): void
     {
         RateLimiter::for('api', function (Request $request) {

--- a/database/migrations/2025_09_14_175404_create_api_keys_table.php
+++ b/database/migrations/2025_09_14_175404_create_api_keys_table.php
@@ -1,0 +1,24 @@
+﻿<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('api_keys', function (Blueprint $table) {
+            $table->id();
+            $table->string('api_key', 64)->unique();  // unique API key (>= 40 chars; we use 64)
+            $table->string('label', 64)->nullable();  // optional label
+            $table->boolean('active')->default(true); // active by default
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('api_keys');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\PackageController;
 use App\Http\Controllers\CompanyController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\LabResultsInboxController;
 
 /*
 |--------------------------------------------------------------------------
@@ -35,3 +36,6 @@ Route::group(['prefix' => 'package'], function () {
 Route::group(['prefix' => 'company'], function () {
     Route::get('get-data-company',  [CompanyController::class, 'getDataCompany']);
 });
+
+Route::post('/lab-results/inbox', [LabResultsInboxController::class, 'store'])
+    ->middleware(['verify.apikey','throttle:labresults']);


### PR DESCRIPTION
# Lab Results Inbox API (staging) — `POST /api/lab-results/inbox`

### Summary
Implements a minimal, secure endpoint to receive per-patient analyzer results (TC3060 chemistry / TEK8520 hematology), stage them in `public.lab_results_inbox_t`, and return the DB-resolved `mcu_id`/`status`. Promotion remains manual via the existing DB function.

- **Auth:** `X-API-Key` (DB table `api_keys`)
- **Throttle:** named limiter `labresults` = **60 req/min per API key** (fallback to IP if header missing)
- **Validation:** `source ∈ {TC3060, TEK8520}`, `obx` non-empty; each item has `test_name` + `value`
- **Insert:** payload stored **verbatim**; trigger fills `items_count`, `run_at`, `mcu_id`, `status`
- **Response:** `{ ok:true, inbox_id, mcu_id|null, status }`

### Routing
- `POST /api/lab-results/inbox` → `App\Http\Controllers\Api\LabResultsInboxController@store`
- Middleware: `verify.apikey`, `throttle:labresults`

---

## Confirmations (must-confirm before merge)

- ✅ **No DB logic changes**: did **not** modify `fn_lrit_autoresolve()` / trigger or `fn_promote_lab_inbox(...)`.
- ✅ Single route definition in `routes/api.php` (no duplicate route loading).
- ✅ Middleware alias registered: `verify.apikey` in `Kernel.php`.
- ✅ Named limiter `labresults` keyed by `X-API-Key` (fallback IP) in `RouteServiceProvider`.
- ✅ Insert **only** into `lab_results_inbox_t` (payload verbatim). No auto-promote.
- ✅ `api_keys.api_key` is **UNIQUE**, length 64, `active` default true.

---

## CLI outputs

php artisan --version
Laravel Framework 10.48.23

php -v
PHP 8.3.16 (cli) (NTS Visual C++ 2019 x64)

php artisan route:list | findstr lab-results
POST api/lab-results/inbox ................................... Api\LabResultsInboxController@store

DB driver (via Tinker):

config('database.default'); // "pgsql"
config('database.connections.pgsql.driver'); // "pgsql"


---

## Test evidence (local → staging DB)
**Happy path**
- TC3060 → `{"ok":true,"inbox_id":11,"mcu_id":null,"status":"unmatched"}`
- TEK8520 (new key) → `{"ok":true,"inbox_id":12,"mcu_id":null,"status":"unmatched"}`

**Golden path (resolvable MCU)**
- POST TC3060 with `patient_id="MCU202502040001"` → `{"ok":true,"inbox_id":13,"mcu_id":1129,"status":"new"}`
- Promote: `select * from public.fn_promote_lab_inbox(1129,'TC3060',null)`
  → `{ promoted:true, inbox_id:13, laboratory_id:2153, inserted_count:2 }`

**DB checks**
- `laboratory_t` latest for 1129 → `laboratory_id=2153`
- `laboratory_detail_t` for 2153 → 12 rows total (CBC + ALT + GLU)
- Latest rows: `37(ALT)=12`, `51(GLU/FBG)=92` at the promotion timestamp
- Glucose-per-package respected (only **51** present among 50/51/52)

**Error paths**
- 401 (missing key) ✔️
- 403 (bad key) — handler returns `{"message":"Invalid or inactive API key"}` (pattern verified)
- 422 (invalid payload) — validation errors for `obx` / required fields (pattern verified)
- 429 (rate limit) ✔️

---

## Files touched

app/Http/Controllers/Api/LabResultsInboxController.php
app/Http/Middleware/VerifyApiKey.php
app/Http/Kernel.php
app/Providers/RouteServiceProvider.php
routes/api.php
database/migrations/2025_09_14_175404_create_api_keys_table.php
docs/lab-inbox-api.md


---

## Risk / impact
- **Staging-only** change set; no production branch (`emhealht-release`) touched.
- No changes to DB trigger/functions (`fn_lrit_autoresolve()`, `fn_promote_lab_inbox(...)`).
- Rate limit uses default cache store; can switch to Redis later with config only.

---

## How to test locally (against staging DB)

**Create API key (Tinker)**
```php
use Illuminate\Support\Str;
DB::table('api_keys')->insert(['api_key' => Str::random(40), 'label' => 'Staging Bridge']);

php -S 127.0.0.1:8888 -t public public/index.php

POST examples

See docs/lab-inbox-api.md for PowerShell + curl examples.

Notes / follow-ups (optional)

Admin report for unknown analyzer codes.

Optional /promote endpoint (skipped for now).

Key rotation guidance for staging/prod.

